### PR TITLE
Add publish method to the broker

### DIFF
--- a/lib/disque_jockey/broker.rb
+++ b/lib/disque_jockey/broker.rb
@@ -13,10 +13,14 @@ module DisqueJockey
 
     def acknowledge(job_id)
       response = @client.call('ACKJOB', job_id)
-      # If there is an error acking the job the Disque client 
-      # *returns* an error object but doesn't raise it, 
+      # If there is an error acking the job the Disque client
+      # *returns* an error object but doesn't raise it,
       # so we raise it here ourselves.
       response.is_a?(RuntimeError) ? raise(response) : true
+    end
+
+    def publish(*args)
+      @client.push(*args)
     end
   end
 end

--- a/spec/disque_jockey/broker_spec.rb
+++ b/spec/disque_jockey/broker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module DisqueJockey
   describe Broker do
-    # Note: You actually have to run a Disque server 
+    # Note: You actually have to run a Disque server
     # locally for these tests to pass
     before(:all) do
       begin
@@ -43,7 +43,18 @@ module DisqueJockey
       end
 
       it "raises an error for a bad job id" do
-        expect{@broker.acknowledge('bad_id')}.to raise_error(RuntimeError)
+        expect{ @broker.acknowledge('bad_id') }.to raise_error(RuntimeError)
+      end
+    end
+
+    describe "#publish" do
+      it "publishes a job to Disque" do
+        test_queue = 'publish_test_queue'
+        test_job = 'job'
+        @broker.publish(test_queue, test_job, 1000)
+        fetched = @client.fetch(from: ['publish_test_queue']).first
+        expect(fetched.first).to eq test_queue
+        expect(fetched.last).to eq test_job
       end
     end
 


### PR DESCRIPTION
@StevenJL Adding a publish method here to make it easier to write the ActiveJobAdapter for Rails.  This will also make it more convenient for workers to publish to queues while they perform their work (so long as we add it to the docs).  I'll be working on the ActiveJobAdapter today, I'll let you know how progress goes.
