### PR TITLE
Add fast acknowledgement option to workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ disque_jockey start --env=production --daemonize=true --worker-groups=10  --node
 ````
 
 Messages successfully handled by a worker (ie no exceptions raised from the handle method) will be acknowledged and removed from the queue.
+## Worker Configuration
+ DisqueJockey::Worker implements some class methods that help you configure your worker.  You call them the same way you call the `subscribe_to` method, at the top of your class.
+
+```ruby
+require 'disque_jockey'
+class HighlyConfiguredWorker < DisqueJockey::Worker
+  subscribe_to 'example-queue'
+  threads 7
+  fast_ack true
+  timeout 5
+  
+  def handle(job)
+    logger.info("Peforming job: #{job}")
+  end
+end
+```
+- *Fast Acknowledgements*: call ````fast_ack true```` to use FASTACKs in disque to acknowledge your messages.  Please note that fast_ack will make it more likely you will process a job more than once in the event of a network partition.  fast_ack is false by default.
+- *Threads*: To devote more threads to your worker class use ````threads 5```` .  Threads are set to two by default and have a maximum value of 10.
+- *Timeout*: To set the number of seconds your worker will process a job until raising a TimeoutError, use ````timeout 45````.  Timeout is set to 30 seconds by default and has a maximum value of 3600 seconds (one hour).
+
 
 ##Roadmap:
 DisqueJockey is not a currently a production-ready system, and there are a number of goals for it that have not been met yet.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ class HighlyConfiguredWorker < DisqueJockey::Worker
   end
 end
 ```
-- *Fast Acknowledgements*: call ````fast_ack true```` to use FASTACKs in disque to acknowledge your messages.  Please note that fast_ack will make it more likely you will process a job more than once in the event of a network partition.  fast_ack is false by default.
+- *Fast Acknowledgements*: call ````fast_ack true```` to use FASTACKs (https://github.com/antirez/disque#fast-acknowledges) in disque to acknowledge your messages.  Please note that fast_ack will make it more likely you will process a job more than once in the event of a network partition.  fast_ack is false by default.
 - *Threads*: To devote more threads to your worker class use ````threads 5```` .  Threads are set to two by default and have a maximum value of 10.
 - *Timeout*: To set the number of seconds your worker will process a job until raising a TimeoutError, use ````timeout 45````.  Timeout is set to 30 seconds by default and has a maximum value of 3600 seconds (one hour).
 

--- a/lib/disque_jockey/broker.rb
+++ b/lib/disque_jockey/broker.rb
@@ -13,8 +13,16 @@ module DisqueJockey
 
     def acknowledge(job_id)
       response = @client.call('ACKJOB', job_id)
-      # If there is an error acking the job the Disque client 
-      # *returns* an error object but doesn't raise it, 
+      # If there is an error acking the job the Disque client
+      # *returns* an error object but doesn't raise it,
+      # so we raise it here ourselves.
+      response.is_a?(RuntimeError) ? raise(response) : true
+    end
+
+    def fast_acknowledge(job_id)
+      response = @client.call('FASTACK', job_id)
+      # If there is an error acking the job the Disque client
+      # *returns* an error object but doesn't raise it,
       # so we raise it here ourselves.
       response.is_a?(RuntimeError) ? raise(response) : true
     end

--- a/lib/disque_jockey/broker.rb
+++ b/lib/disque_jockey/broker.rb
@@ -13,17 +13,20 @@ module DisqueJockey
 
     def acknowledge(job_id)
       response = @client.call('ACKJOB', job_id)
-      # If there is an error acking the job the Disque client
-      # *returns* an error object but doesn't raise it,
-      # so we raise it here ourselves.
-      response.is_a?(RuntimeError) ? raise(response) : true
+      raise_error_or_return_true(response)
     end
 
     def fast_acknowledge(job_id)
       response = @client.call('FASTACK', job_id)
-      # If there is an error acking the job the Disque client
-      # *returns* an error object but doesn't raise it,
-      # so we raise it here ourselves.
+      raise_error_or_return_true(response)
+    end
+
+    private
+
+    # If there is an error acking the job the Disque client
+    # *returns* an error object but doesn't raise it,
+    # so we raise it here ourselves.
+    def raise_error_or_return_true(response)
       response.is_a?(RuntimeError) ? raise(response) : true
     end
   end

--- a/lib/disque_jockey/worker.rb
+++ b/lib/disque_jockey/worker.rb
@@ -11,11 +11,16 @@ module DisqueJockey
     end
 
     class << self
-      attr_reader :queue_name, :thread_count, :timeout_seconds
+      attr_reader :queue_name, :thread_count, :timeout_seconds, :use_fast_ack
 
       # This worker class will subscribe to queue
       def subscribe_to(queue)
         @queue_name = queue
+      end
+
+      # whehter to use Disque fast acknowledgements
+      def fast_ack(value)
+        @use_fast_ack = !!value
       end
 
       # minimum number of worker instances of a given worker class.
@@ -36,6 +41,7 @@ module DisqueJockey
         # these are the defaults
         type.threads 2
         type.timeout 30
+        type.fast_ack false
         # register the new worker type so we can start giving it jobs
         Supervisor.register_worker(type)
       end

--- a/lib/disque_jockey/worker_pool.rb
+++ b/lib/disque_jockey/worker_pool.rb
@@ -37,7 +37,7 @@ module DisqueJockey
     def handle_job(worker, job, job_id)
       begin
         Timeout::timeout(@worker_class.timeout_seconds) { worker.handle(job) }
-        @broker.acknowledge(job_id)
+        @worker_class.use_fast_ack ? @broker.fast_acknowledge(job_id) : @broker.acknowledge(job_id)
       rescue StandardError => exception
         worker.log_exception(exception)
         # TODO: Need to implement retry logic
@@ -47,7 +47,7 @@ module DisqueJockey
     end
 
     def build_worker_pool
-      @worker_class.thread_count.times { @pool << @worker_class.new(Logger) }      
+      @worker_class.thread_count.times { @pool << @worker_class.new(Logger) }
     end
 
   end

--- a/spec/disque_jockey/broker_spec.rb
+++ b/spec/disque_jockey/broker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module DisqueJockey
   describe Broker do
-    # Note: You actually have to run a Disque server 
+    # Note: You actually have to run a Disque server
     # locally for these tests to pass
     before(:all) do
       begin
@@ -34,7 +34,7 @@ module DisqueJockey
     end
 
     describe '#acknowledge' do
-      it "returns removes job from queue and returns true if it succeeds" do
+      it "removes job from queue and returns true if it succeeds" do
         @client.call('DEBUG', 'FLUSHALL')
         job_id = @client.push('test_queue', 'test job', 1000)
         expect(@client.call('QLEN', 'test_queue')).to eq 1
@@ -44,6 +44,20 @@ module DisqueJockey
 
       it "raises an error for a bad job id" do
         expect{@broker.acknowledge('bad_id')}.to raise_error(RuntimeError)
+      end
+    end
+
+    describe "#fast_acknowledge" do
+      it "raises an error for a bad job id" do
+        expect{@broker.fast_acknowledge('bad_id')}.to raise_error(RuntimeError)
+      end
+
+      it "acknowledges jobs" do
+        @client.call('DEBUG', 'FLUSHALL')
+        job_id = @client.push('test_queue', 'test job', 1000)
+        expect(@client.call('QLEN', 'test_queue')).to eq 1
+        expect(@broker.fast_acknowledge(job_id)).to eq true
+        expect(@client.call('QLEN', 'test_queue')).to eq 0
       end
     end
 

--- a/spec/disque_jockey/worker_shared_setup.rb
+++ b/spec/disque_jockey/worker_shared_setup.rb
@@ -6,9 +6,10 @@ shared_context "worker setup" do
       subscribe_to "test"
       def handle(job); end
     end
-    
+
     class SecondSpecWorker < DisqueJockey::Worker
       subscribe_to "other-test"
+      fast_ack true
       threads 1
       timeout 1
       def handle(job); end

--- a/spec/disque_jockey/worker_spec.rb
+++ b/spec/disque_jockey/worker_spec.rb
@@ -41,7 +41,7 @@ describe DisqueJockey::Worker do
   context "class methods"
   context "overrides" do
 
-    it "allows overrides for timeout, and thread_count" do
+    it "allows overrides for timeout, threads, and fast_ack" do
       # These traits are set in worker_shared_setup.rb
       expect(SecondSpecWorker.timeout_seconds).to be(1)
       expect(SecondSpecWorker.thread_count).to be(1)

--- a/spec/disque_jockey/worker_spec.rb
+++ b/spec/disque_jockey/worker_spec.rb
@@ -6,8 +6,8 @@ describe DisqueJockey::Worker do
   include_context "worker setup"
 
   it "defines class methods" do
-    [ :queue_name, :thread_count, :timeout_seconds, 
-      :subscribe_to, :timeout, :threads
+    [ :queue_name, :thread_count, :timeout_seconds,
+      :subscribe_to, :timeout, :threads, :fast_ack, :use_fast_ack
     ].each do |method|
       expect(DisqueJockey::Worker).to respond_to(method)
     end
@@ -24,26 +24,34 @@ describe DisqueJockey::Worker do
   end
 
   context "defaults" do
-    it "sets a default for timeout" do
+    it "timeout is 30 seconds" do
       expect(SpecWorker.timeout_seconds).to be(30)
     end
 
-    it "sets a default for thread_count" do
+    it "thread_count is 2" do
       expect(SpecWorker.thread_count).to be(2)
     end
+
+    it "use_fast_ack is false" do
+      expect(SpecWorker.use_fast_ack).to eq false
+    end
+
   end
 
   context "class methods"
   context "overrides" do
+
     it "allows overrides for timeout, and thread_count" do
+      # These traits are set in worker_shared_setup.rb
       expect(SecondSpecWorker.timeout_seconds).to be(1)
       expect(SecondSpecWorker.thread_count).to be(1)
+      expect(SecondSpecWorker.use_fast_ack).to be(true)
     end
   end
-  
+
   context "instance methods"
   describe "#initialize" do
-    before do 
+    before do
       @logger = double(:logger, info: true, error: true, warn: true)
       allow(@logger).to receive(:new).and_return(@logger)
     end


### PR DESCRIPTION
This PR allows workers to use the Disque FASTACK option on a per-worker basis (see https://github.com/antirez/disque#fast-acknowledges for details).
